### PR TITLE
Handle the bindgen test failure in Windows

### DIFF
--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/CommandTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/CommandTest.java
@@ -17,7 +17,6 @@
  */
 package org.ballerinalang.bindgen;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -67,7 +66,7 @@ public abstract class CommandTest {
                     try {
                         Files.delete(path);
                     } catch (IOException e) {
-                        Assert.fail(e.getMessage(), e);
+                        // Ignore exceptions in the test temp file cleanup
                     }
                 });
         console.close();

--- a/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/CommandTest.java
+++ b/misc/ballerina-bindgen/src/test/java/org/ballerinalang/bindgen/CommandTest.java
@@ -66,7 +66,7 @@ public abstract class CommandTest {
                     try {
                         Files.delete(path);
                     } catch (IOException e) {
-                        // Ignore exceptions in the test temp file cleanup
+                        // TODO: Fix the ignoring of exceptions in the test temp file cleanup
                     }
                 });
         console.close();


### PR DESCRIPTION
## Purpose
Cleaning up of some of the bindgen test temp files is intermittently giving IOExceptions in Windows. This PR ignores the IOExceptions without breaking the test cases.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
